### PR TITLE
Respect source and target branches when assigning branch columns

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -528,11 +528,13 @@ fn run(
     if settings.debug {
         for branch in &graph.branches {
             eprintln!(
-                "{} (col {}) ({:?}) {}",
+                "{} (col {}) ({:?}) {} s: {:?}, t: {:?}",
                 branch.name,
                 branch.visual.column.unwrap_or(99),
                 branch.range,
-                if branch.is_merged { "m" } else { "" }
+                if branch.is_merged { "m" } else { "" },
+                branch.visual.source_order_group,
+                branch.visual.target_order_group
             );
         }
     }

--- a/src/print/format.rs
+++ b/src/print/format.rs
@@ -73,7 +73,6 @@ lazy_static! {
 }
 
 /// Format a commit for `CommitFormat::Format(String)`.
-#[allow(dead_code)]
 pub fn format_commit(
     format: &str,
     commit: &Commit,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -25,10 +25,6 @@ pub enum BranchOrder {
     /// For branches with equal length, branches ending last are inserted first.
     /// Reverse (arg = false): Branches ending first are inserted first.
     LongestFirst(bool),
-    /// Branches ending last are inserted left-most.
-    ///
-    /// Reverse (arg = false): Branches starting first are inserted left-most.
-    FirstComeFirstServed(bool),
 }
 
 /// Top-level settings


### PR DESCRIPTION
The aim is to e.g. have feature branches that deviate from and merge into other feature branches further right than feature branches that merge into master or develop.

Removed FCFS ordering.

Code simplifications, re-ordering in conditions to avoid unnecessary RegEx matching

Fixes #8.