### PR TITLE
Short forms for styles and formats, introduced -f for --format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The image below shows an example using the [GitFlow branching model](https://nvi
 
 > GitFlow was chosen for its complexity, while any other branching model is supported, including user-defined ones.
 
-![Graph comparison](https://user-images.githubusercontent.com/44003176/103142438-4e5b1c80-4703-11eb-8b23-9829eecdc54c.jpg)
+![Graph comparison between tools](https://user-images.githubusercontent.com/44003176/103466403-36a81780-4d45-11eb-90cc-167d210d7a52.png)
 
 Decide for yourself which graph is the most comprehensible. :sunglasses:
 
@@ -96,7 +96,12 @@ Although doing some heavy lifting when determining the layout of a graph, git-gr
 
 As a benchmarking example, the repository of the the Rust package manager `cargo` is used. It has over 10.000 commits and 50 active branches. Parsing (i.e. determining arrangement and colors of branches) takes approx. 750ms, and printing the entire graph with commit summaries, piped to a file, takes approx. 400ms. Required memory is about 30 MB.
 
-For an average repository with a few hundred commits, parsing takes a few tens of milliseconds and memory usage is below 5 MB.
+For an average repository with a few hundred commits, parsing takes a few tens to 100 milliseconds and memory usage is below 5 MB.
+
+| Repo (commits)      | Parsing | RAM  |
+| ------------------- | -------:| ----:|
+| cargo (10k)         | 750ms   | 30MB |
+| avg (a few hundred) | ≈100ms  | <5MB |
 
 ## Limitations
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -53,6 +53,8 @@ Git-graph supports different styles. Besides the default `normal` alias `thin`, 
 git-graph --style round
 ```
 
+![styles](https://user-images.githubusercontent.com/44003176/103467621-357ce780-4d51-11eb-8ff9-dd7be8b40f84.png)
+
 **Formatting**
 
 Git-graph supports predefined as well as custom commit formatting through the option `--format`. Available presets follow Git: `oneline` (the default), `short`, `medium` and `full`. For details and custom formatting, see section [Formatting](#formatting).
@@ -84,7 +86,7 @@ FLAGS:
     -l, --local       Show only local branches, no remotes.
         --no-color    Print without colors. Missing color support should be detected
                       automatically (e.g. when piping to a file).
-                      Overrides option `--color`
+                      Overrides option '--color'
         --no-pager    Use no pager (print everything at once without prompt).
     -S, --sparse      Print a less compact graph: merge lines point to target lines
                       rather than merge commits.
@@ -94,19 +96,21 @@ FLAGS:
 OPTIONS:
         --color <color>      Specify when colors should be used. One of [auto|always|never].
                              Default: auto.
-        --format <format>    Commit format. One of [oneline|short|medium|full|"<string>"].
+    -f, --format <format>    Commit format. One of [oneline|short|medium|full|"<string>"].
+                               (First character can be used as abbreviation, e.g. '-f m')
                              Default: oneline.
-                             For placeholders supported in "<string>", consult `git-graph --help`
+                             For placeholders supported in "<string>", consult 'git-graph --help'
     -n, --max-count <n>      Maximum number of commits
     -m, --model <model>      Branching model. Available presets are [simple|git-flow|none].
                              Default: git-flow.
                              Permanently set the model for a repository with
                              > git-graph model <model>
     -p, --path <path>        Open repository from this path or above. Default '.'
-    -s, --style <style>      Output style. One of [normal|thin|round|bold|double|ascii].
-    -w, --wrap <wrap>        Line wrapping for formatted commit text. Default: `auto 0 8`
+    -s, --style <style>      Output style. One of [normal/thin|round|bold|double|ascii].
+                               (First character can be used as abbreviation, e.g. '-s r')
+    -w, --wrap <wrap>        Line wrapping for formatted commit text. Default: 'auto 0 8'
                              Argument format: [<width>|auto|none[ <indent1>[ <indent2>]]]
-                             For examples, consult `git-graph --help`
+                             For examples, consult 'git-graph --help'
 
 SUBCOMMANDS:
     help     Prints this message or the help of the given subcommand(s)
@@ -120,6 +124,48 @@ For longer explanations, use `git-graph --help`.
 Formatting can be specified with the `--format` option.
 
 Predefined formats are `oneline` (the default), `short`, `medium` and `full`. They should behave like the Git formatting presets described in the [Git documentation](https://git-scm.com/docs/pretty-formats).
+
+**oneline**
+
+```
+<hash> [<refs>] <title line>
+```
+
+**short**
+
+```
+commit <hash> [<refs>]
+Author: <author>
+
+<title line>
+```
+
+**medium**
+
+```
+commit <hash> [<refs>]
+Author: <author>
+Date:   <author date>
+
+<title line>
+
+<full commit message>
+```
+
+**full**
+
+```
+commit <hash> [<refs>]
+Author: <author>
+Commit: <committer>
+Date:   <author date>
+
+<title line>
+
+<full commit message>
+```
+
+### Custom formatting
 
 Formatting strings use a subset of the placeholders available in `git log --format="..."`:
 
@@ -179,7 +225,7 @@ File names of any `.toml` files in the `models` directory can be used in paramet
 git-graph --model my-model
 ```
 
-**Branching model files** are in TOML format and have several sections, relying on Regular Expressions to categorize branches. The listing below shows the `git-flow` model (slightly abbreviated) with explanatory comments.
+**Branching model files** are in [TOML](https://toml.io/en/) format and have several sections, relying on Regular Expressions to categorize branches. The listing below shows the `git-flow` model (slightly abbreviated) with explanatory comments.
 
 ```toml
 # RegEx patterns for branch groups by persistence, from most persistent
@@ -249,7 +295,9 @@ matches = [
         '^(master|main)$',
         ['blue'],
     ],
-    ...
+    [ 
+        '...',
+    ]
 ]
 unknown = ['gray']
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ fn from_args() -> Result<(), String> {
                 .long("no-color")
                 .help("Print without colors. Missing color support should be detected\n\
                        automatically (e.g. when piping to a file).\n\
-                       Overrides option `--color`")
+                       Overrides option '--color'")
                 .required(false)
                 .takes_value(false),
         )
@@ -134,7 +134,8 @@ fn from_args() -> Result<(), String> {
             Arg::with_name("style")
                 .long("style")
                 .short("s")
-                .help("Output style. One of [normal|thin|round|bold|double|ascii].")
+                .help("Output style. One of [normal/thin|round|bold|double|ascii].\n  \
+                         (First character can be used as abbreviation, e.g. '-s r')")
                 .required(false)
                 .takes_value(true),
         )
@@ -142,10 +143,10 @@ fn from_args() -> Result<(), String> {
             Arg::with_name("wrap")
                 .long("wrap")
                 .short("w")
-                .help("Line wrapping for formatted commit text. Default: `auto 0 8`\n\
+                .help("Line wrapping for formatted commit text. Default: 'auto 0 8'\n\
                        Argument format: [<width>|auto|none[ <indent1>[ <indent2>]]]\n\
-                       For examples, consult `git-graph --help`")
-                .long_help("Line wrapping for formatted commit text. Default: `auto 0 8`\n\
+                       For examples, consult 'git-graph --help'")
+                .long_help("Line wrapping for formatted commit text. Default: 'auto 0 8'\n\
                        Argument format: [<width>|auto|none[ <indent1>[ <indent2>]]]\n\
                        Examples:\n    \
                            git-graph --wrap auto\n    \
@@ -153,7 +154,7 @@ fn from_args() -> Result<(), String> {
                            git-graph --wrap none\n    \
                            git-graph --wrap 80\n    \
                            git-graph --wrap 80 0 8\n\
-                       `auto` uses the terminal's width if on a terminal.")
+                       'auto' uses the terminal's width if on a terminal.")
                 .required(false)
                 .min_values(0)
                 .max_values(3),
@@ -161,10 +162,13 @@ fn from_args() -> Result<(), String> {
         .arg(
             Arg::with_name("format")
                 .long("format")
-                .help("Commit format. One of [oneline|short|medium|full|\"<string>\"].\n\
+                .short("f")
+                .help("Commit format. One of [oneline|short|medium|full|\"<string>\"].\n  \
+                         (First character can be used as abbreviation, e.g. '-f m')\n\
                        Default: oneline.\n\
-                       For placeholders supported in \"<string>\", consult `git-graph --help`")
-                .long_help("Commit format. One of [oneline|short|medium|full|\"<string>\"].\n\
+                       For placeholders supported in \"<string>\", consult 'git-graph --help'")
+                .long_help("Commit format. One of [oneline|short|medium|full|\"<string>\"].\n  \
+                              (First character can be used as abbreviation, e.g. '-f m')\n\
                             Formatting placeholders for \"<string>\":\n    \
                                 %n    newline\n    \
                                 %H    commit hash\n    \
@@ -178,11 +182,11 @@ fn from_args() -> Result<(), String> {
                                 %an   author name\n    \
                                 %ae   author email\n    \
                                 %ad   author date\n    \
-                                %as   author date in short format `YYYY-MM-DD`\n    \
+                                %as   author date in short format 'YYYY-MM-DD'\n    \
                                 %cn   committer name\n    \
                                 %ce   committer email\n    \
                                 %cd   committer date\n    \
-                                %cs   committer date in short format `YYYY-MM-DD`\n    \
+                                %cs   committer date in short format 'YYYY-MM-DD'\n    \
                                 \n    \
                                 If you add a + (plus sign) after % of a placeholder,\n       \
                                    a line-feed is inserted immediately before the expansion if\n       \
@@ -190,7 +194,7 @@ fn from_args() -> Result<(), String> {
                                 If you add a - (minus sign) after % of a placeholder, all\n       \
                                    consecutive line-feeds immediately preceding the expansion are\n       \
                                    deleted if and only if the placeholder expands to an empty string.\n    \
-                                If you add a ` ` (space) after % of a placeholder, a space is\n       \
+                                If you add a ' ' (space) after % of a placeholder, a space is\n       \
                                    inserted immediately before the expansion if and only if\n       \
                                    the placeholder expands to a non-empty string.\n\
                             \n    \

--- a/src/print/format.rs
+++ b/src/print/format.rs
@@ -22,10 +22,10 @@ impl FromStr for CommitFormat {
 
     fn from_str(str: &str) -> Result<Self, Self::Err> {
         match str {
-            "oneline" => Ok(CommitFormat::OneLine),
-            "short" => Ok(CommitFormat::Short),
-            "medium" => Ok(CommitFormat::Medium),
-            "full" => Ok(CommitFormat::Full),
+            "oneline" | "o" => Ok(CommitFormat::OneLine),
+            "short" | "s" => Ok(CommitFormat::Short),
+            "medium" | "m" => Ok(CommitFormat::Medium),
+            "full" | "f" => Ok(CommitFormat::Full),
             str => Ok(CommitFormat::Format(str.to_string())),
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -295,11 +295,11 @@ impl FromStr for Characters {
 
     fn from_str(str: &str) -> Result<Self, Self::Err> {
         match str {
-            "normal" | "thin" => Ok(Characters::thin()),
-            "round" => Ok(Characters::round()),
-            "bold" => Ok(Characters::bold()),
-            "double" => Ok(Characters::double()),
-            "ascii" => Ok(Characters::ascii()),
+            "normal" | "thin" | "n" | "t" => Ok(Characters::thin()),
+            "round" | "r" => Ok(Characters::round()),
+            "bold" | "b" => Ok(Characters::bold()),
+            "double" | "d" => Ok(Characters::double()),
+            "ascii" | "a" => Ok(Characters::ascii()),
             _ => Err(format!("Unknown characters/style '{}'. Must be one of [normal|thin|round|bold|double|ascii]", str)),
         }
     }


### PR DESCRIPTION
Allows e.g. `-s r` for `-s round`, and `-f m` for `-f medium`