### PR TITLE
Abort with a more helpful error message on shallow clones

### DIFF
--- a/src/print/svg.rs
+++ b/src/print/svg.rs
@@ -87,7 +87,7 @@ pub fn print_svg(graph: &GitGraph, settings: &Settings) -> Result<String, String
 
     let mut out: Vec<u8> = vec![];
     svg::write(&mut out, &document).map_err(|err| err.to_string())?;
-    String::from_utf8(out).map_err(|err| err.to_string())
+    Ok(String::from_utf8(out).unwrap_or_else(|_| "Invalid UTF8 character.".to_string()))
 }
 
 fn commit_dot(index: usize, column: usize, color: &str, filled: bool) -> Circle {


### PR DESCRIPTION
Shallow clones are not supported by [libgit2](https://github.com/libgit2/libgit2) (see https://github.com/libgit2/libgit2/issues/3058).
To avoid confucing crashes, report the reason as error message.

Fixes #47.