### PR TITLE
Fix for missing tags due to tag id inconsistency, increment version to 0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "git-graph"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "atty",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-graph"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Martin Lange <martin_lange_@gmx.net>"]
 description = "Command line tool to show clear git graphs arranged for your branching model"
 repository = "https://github.com/mlange-42/git-graph.git"


### PR DESCRIPTION
Tag ids/hashes are inconsistent in git2-rs / libgit2. Sometimes, the tag's id are separate ids of tags (find_tag), sometimes thay are the ids of the target commit.

To fix the problem, first look for the id with find_tag, then with find_commit if not found with find_tags