### PR TITLE
Adds instructions on README.md to use the git-graph.toml config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ git-graph --help
 
 For **styles** and commit **formatting**, see the [manual](docs/manual.md).
 
+## Config file
+
+There is a sample `git-graph.toml.sample` file provided in this repository containing the default configuration
+for `git-graph`.
+
+Copy and paste the file on yout `.git/` folder, change its name to `.git/git-graph.toml` and tweak it to fit your needs
+
 ## Custom branching models
 
 Branching models are configured using the files in `APP_DATA/git-graph/models`. 

--- a/git-graph.toml.sample
+++ b/git-graph.toml.sample
@@ -1,0 +1,1 @@
+model="git-flow"


### PR DESCRIPTION
It took me some time to figure out how to use the `git-graph.toml` file with the default configuration for `--model <model>`, I've had to read the code to figure out where to put the config file.

This PR provides a sample `git-graph.toml.sample` file and instructions where to copy and paste it.