### PR TITLE
Feature Addition: Reverse Option

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -683,8 +683,8 @@ fn extract_branches(
 
 /// Traces back branches by following 1st commit parent,
 /// until a commit is reached that already has a trace.
-fn trace_branch<'repo>(
-    repository: &'repo Repository,
+fn trace_branch(
+    repository: &Repository,
     commits: &mut [CommitInfo],
     indices: &HashMap<Oid, usize>,
     branches: &mut [BranchInfo],

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,14 @@ fn from_args() -> Result<(), String> {
                  git-graph model <model>     -> Permanently set model <model> for this repo",
         )
         .arg(
+            Arg::new("reverse")
+                .long("reverse")
+                .short('r')
+                .help("Reverse the order of commits.")
+                .required(false)
+                .num_args(0),
+        )
+        .arg(
             Arg::new("path")
                 .long("path")
                 .short('p')
@@ -272,6 +280,8 @@ fn from_args() -> Result<(), String> {
 
     let include_remote = !matches.get_flag("local");
 
+    let reverse_commit_order = matches.get_flag("reverse");
+
     let svg = matches.get_flag("svg");
     let pager = !matches.get_flag("no-pager");
     let compact = !matches.get_flag("sparse");
@@ -280,6 +290,12 @@ fn from_args() -> Result<(), String> {
         .get_one::<String>("style")
         .map(|s| Characters::from_str(s))
         .unwrap_or_else(|| Ok(Characters::thin()))?;
+
+    let style = if reverse_commit_order {
+        style.reverse()
+    } else {
+        style
+    };
 
     let model = get_model(
         &repository,
@@ -364,6 +380,7 @@ fn from_args() -> Result<(), String> {
     };
 
     let settings = Settings {
+        reverse_commit_order,
         debug,
         colored,
         compact,

--- a/src/print/unicode.rs
+++ b/src/print/unicode.rs
@@ -189,6 +189,11 @@ pub fn print_unicode(graph: &GitGraph, settings: &Settings) -> Result<UnicodeGra
         }
     }
 
+    if settings.reverse_commit_order {
+        text_lines.reverse();
+        grid.reverse();
+    }
+
     let lines = print_graph(&settings.characters, &grid, text_lines, settings.colored);
 
     Ok((lines.0, lines.1, index_map))
@@ -681,6 +686,10 @@ impl Grid {
             height,
             data: vec![initial; width * height],
         }
+    }
+
+    pub fn reverse(&mut self) {
+        self.data.reverse();
     }
     pub fn index(&self, x: usize, y: usize) -> usize {
         y * self.width + x

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -348,9 +348,6 @@ impl Characters {
         chars.swap(12, 13);
         chars.swap(14, 15);
 
-        return Characters {
-            chars
-        };
-
+        Characters { chars }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,6 +29,8 @@ pub enum BranchOrder {
 
 /// Top-level settings
 pub struct Settings {
+    /// Reverse the order of commits
+    pub reverse_commit_order: bool,
     /// Debug printing and drawing
     pub debug: bool,
     /// Compact text-based graph
@@ -335,5 +337,20 @@ impl Characters {
         Characters {
             chars: " *o|-+'..'||++<>".chars().collect(),
         }
+    }
+
+    pub fn reverse(self) -> Self {
+        let mut chars = self.chars;
+
+        chars.swap(6, 8);
+        chars.swap(7, 9);
+        chars.swap(10, 11);
+        chars.swap(12, 13);
+        chars.swap(14, 15);
+
+        return Characters {
+            chars
+        };
+
     }
 }


### PR DESCRIPTION
Hey mlange-42,

Just wanted to drop in a pull request for something you might find a bit hacky, but I found myself needing a reverse option. The approach here is a bit unconventional – instead of overhauling the code, I went for reversing the text_lines and grid. To tackle the issue of characters facing the wrong direction, I flipped them (so a 'left-up' becomes 'left-down', and so on).

It might be more ideal to adjust how the Character struct is accessed with the reverse option in mind, but that would require a significant refactor of the existing code. From what I've tested, it looks like it works pretty well across different character sets. Would love to hear your thoughts on this and if it's something you'd consider merging.

Cheers!