### PR TITLE
Add trunk as supported main branch name for git-flow

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -242,7 +242,7 @@ git-graph --model my-model
 # to most short-leved branches. This is used to back-trace branches.
 # Branches not matching any pattern are assumed least persistent.
 persistence = [
-    '^(master|main)$', # Matches exactly `master` or `main`
+    '^(master|main|trunk)$', # Matches exactly `master` or `main`  or `trunk`
     '^(develop|dev)$',
     '^feature.*$',     # Matches everything starting with `feature`
     '^release.*$',
@@ -251,12 +251,12 @@ persistence = [
 ]
 
 # RegEx patterns for visual ordering of branches, from left to right.
-# Here, `master` or `main` are shown left-most, followed by branches
+# Here, `master`, `main` or `trunk` are shown left-most, followed by branches
 # starting with `hotfix` or `release`, followed by `develop` or `dev`.
 # Branches not matching any pattern (e.g. starting with `feature`)
 # are displayed further to the right.
 order = [
-    '^(master|main)$',      # Matches exactly `master` or `main`
+    '^(master|main|trunk)$',      # Matches exactly `master` or `main` or `trunk`
     '^(hotfix|release).*$', # Matches everything starting with `hotfix` or `release`
     '^(develop|dev)$',      # Matches exactly `develop` or `dev`
 ]
@@ -268,7 +268,7 @@ order = [
 # will be used alternating (see e.g. `feature...`).
 matches = [
     [
-        '^(master|main)$',
+        '^(master|main|trunk)$',
         ['bright_blue'],
     ],
     [
@@ -303,7 +303,7 @@ unknown = ['white']
 [svg_colors]
 matches = [
     [
-        '^(master|main)$',
+        '^(master|main|trunk)$',
         ['blue'],
     ],
     [ 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -78,7 +78,7 @@ impl BranchSettingsDef {
     pub fn git_flow() -> Self {
         BranchSettingsDef {
             persistence: vec![
-                r"^(master|main)$".to_string(),
+                r"^(master|main|trunk)$".to_string(),
                 r"^(develop|dev)$".to_string(),
                 r"^feature.*$".to_string(),
                 r"^release.*$".to_string(),
@@ -86,14 +86,14 @@ impl BranchSettingsDef {
                 r"^bugfix.*$".to_string(),
             ],
             order: vec![
-                r"^(master|main)$".to_string(),
+                r"^(master|main|trunk)$".to_string(),
                 r"^(hotfix|release).*$".to_string(),
                 r"^(develop|dev)$".to_string(),
             ],
             terminal_colors: ColorsDef {
                 matches: vec![
                     (
-                        r"^(master|main)$".to_string(),
+                        r"^(master|main|trunk)$".to_string(),
                         vec!["bright_blue".to_string()],
                     ),
                     (
@@ -116,7 +116,10 @@ impl BranchSettingsDef {
 
             svg_colors: ColorsDef {
                 matches: vec![
-                    (r"^(master|main)$".to_string(), vec!["blue".to_string()]),
+                    (
+                        r"^(master|main|trunk)$".to_string(),
+                        vec!["blue".to_string()],
+                    ),
                     (r"^(develop|dev)$".to_string(), vec!["orange".to_string()]),
                     (
                         r"^(feature|fork/).*$".to_string(),
@@ -134,12 +137,15 @@ impl BranchSettingsDef {
     /// Simple feature-based model.
     pub fn simple() -> Self {
         BranchSettingsDef {
-            persistence: vec![r"^(master|main)$".to_string()],
-            order: vec![r"^tags/.*$".to_string(), r"^(master|main)$".to_string()],
+            persistence: vec![r"^(master|main|trunk)$".to_string()],
+            order: vec![
+                r"^tags/.*$".to_string(),
+                r"^(master|main|trunk)$".to_string(),
+            ],
             terminal_colors: ColorsDef {
                 matches: vec![
                     (
-                        r"^(master|main)$".to_string(),
+                        r"^(master|main|trunk)$".to_string(),
                         vec!["bright_blue".to_string()],
                     ),
                     (r"^tags/.*$".to_string(), vec!["bright_green".to_string()]),
@@ -155,7 +161,10 @@ impl BranchSettingsDef {
 
             svg_colors: ColorsDef {
                 matches: vec![
-                    (r"^(master|main)$".to_string(), vec!["blue".to_string()]),
+                    (
+                        r"^(master|main|trunk)$".to_string(),
+                        vec!["blue".to_string()],
+                    ),
                     (r"^tags/.*$".to_string(), vec!["green".to_string()]),
                 ],
                 unknown: vec![


### PR DESCRIPTION
Trunk Based Development is an easyfied version of git-flow, useful for smaller projects.

It is a quite common convention to call the main branch trunk, to directly show that the project uses trunk based Development.

This PR adds trunk as a possible name for the main branch in gitflow, so it's also correctly shown on the complete left.