### PR TITLE
Add skip-repo-owner-validation cli options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.iml
+/.idea/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ pub mod graph;
 pub mod print;
 pub mod settings;
 
-pub fn get_repo<P: AsRef<Path>>(path: P) -> Result<Repository, git2::Error> {
+pub fn get_repo<P: AsRef<Path>>(path: P, skip_repo_owner_validation: bool) -> Result<Repository, git2::Error> {
+    if(skip_repo_owner_validation) {
+        unsafe { git2::opts::set_verify_owner_validation(false)? }
+    }
     Repository::discover(path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub fn get_repo<P: AsRef<Path>>(
     path: P,
     skip_repo_owner_validation: bool,
 ) -> Result<Repository, git2::Error> {
-    if (skip_repo_owner_validation) {
+    if skip_repo_owner_validation {
         unsafe { git2::opts::set_verify_owner_validation(false)? }
     }
     Repository::discover(path)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,11 @@ pub mod graph;
 pub mod print;
 pub mod settings;
 
-pub fn get_repo<P: AsRef<Path>>(path: P, skip_repo_owner_validation: bool) -> Result<Repository, git2::Error> {
-    if(skip_repo_owner_validation) {
+pub fn get_repo<P: AsRef<Path>>(
+    path: P,
+    skip_repo_owner_validation: bool,
+) -> Result<Repository, git2::Error> {
+    if (skip_repo_owner_validation) {
         unsafe { git2::opts::set_verify_owner_validation(false)? }
     }
     Repository::discover(path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,6 +215,15 @@ fn from_args() -> Result<(), String> {
                 .required(false)
                 .num_args(1),
         )
+        .arg(
+            Arg::new("skip-repo-owner-validation")
+                .long("skip-repo-owner-validation")
+                .help("Skip owner validation for the repository.\n\
+                       This will turn off libgit2's owner validation, which may increase security risks.\n\
+                       Please do not disable this validation for repositories you do not trust.")
+                .required(false)
+                .num_args(0)
+        )
         .subcommand(Command::new("model")
             .about("Prints or permanently sets the branching model for a repository.")
             .arg(
@@ -246,9 +255,13 @@ fn from_args() -> Result<(), String> {
         }
     }
 
+    let skip_repo_owner_validation = matches.get_flag("skip-repo-owner-validation");
+    if(skip_repo_owner_validation) {
+        print!("Warning: skip-repo-owner-validation is set! \n");
+    }
     let dot = ".".to_string();
     let path = matches.get_one::<String>("path").unwrap_or(&dot);
-    let repository = get_repo(path)
+    let repository = get_repo(path, skip_repo_owner_validation)
         .map_err(|err| format!("ERROR: {}\n       Navigate into a repository before running git-graph, or use option --path", err.message()))?;
 
     if let Some(matches) = matches.subcommand_matches("model") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,7 +256,7 @@ fn from_args() -> Result<(), String> {
     }
 
     let skip_repo_owner_validation = matches.get_flag("skip-repo-owner-validation");
-    if(skip_repo_owner_validation) {
+    if (skip_repo_owner_validation) {
         print!("Warning: skip-repo-owner-validation is set! \n");
     }
     let dot = ".".to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,8 +256,8 @@ fn from_args() -> Result<(), String> {
     }
 
     let skip_repo_owner_validation = matches.get_flag("skip-repo-owner-validation");
-    if (skip_repo_owner_validation) {
-        print!("Warning: skip-repo-owner-validation is set! \n");
+    if skip_repo_owner_validation {
+        println!("Warning: skip-repo-owner-validation is set! ");
     }
     let dot = ".".to_string();
     let path = matches.get_one::<String>("path").unwrap_or(&dot);


### PR DESCRIPTION
Motivation: When running on Windows, the following error will be triggered
```
🕙 09:03:11 ➜ > git-graph --path .
ERROR: repository path 'c:/path-to-git-repo' is not owned by current user
       Navigate into a repository before running git-graph, or use option --path
```

Now, this check can be disabled by explicitly specifying the --skip-repo-owner-validation parameter.

opt-in, users are responsible for security checks.