### PR TITLE
Move eprint from library to binary.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -147,7 +147,5 @@ pub fn set_model<P: AsRef<Path>>(
     let str = toml::to_string_pretty(&config).map_err(|err| err.to_string())?;
     std::fs::write(&config_path, str).map_err(|err| err.to_string())?;
 
-    eprint!("Branching model set to '{}'", model);
-
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-//! Command line tool to show clear git graphs arranged for your branching model.
+//! git-graph shows clear git graphs arranged for your branching model.
+//!
+//! It provides both a library and a command line tool.
 
 use git2::Repository;
 use std::path::Path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+//! Command line tool to show clear git graphs arranged for your branching model.
+
 use clap::{crate_version, Arg, Command};
 use crossterm::cursor::MoveToColumn;
 use crossterm::event::{Event, KeyCode, KeyModifiers};
@@ -273,7 +275,10 @@ fn from_args() -> Result<(), String> {
                     Some(model) => print!("{}", model),
                 }
             }
-            Some(model) => set_model(&repository, model, REPO_CONFIG_FILE, &models_dir)?,
+            Some(model) => {
+                set_model(&repository, model, REPO_CONFIG_FILE, &models_dir)?;
+                eprint!("Branching model set to '{}'", model);
+            }
         };
         return Ok(());
     }


### PR DESCRIPTION
When using git-graph as a library, there should be no output to stderr.