### PR TITLE
Add some vim-style keybinds for navigation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -516,7 +516,7 @@ fn print_paged(graph_lines: &[String], text_lines: &[String]) -> Result<(), Erro
                         start_idx += height as usize - 2;
                         should_update = true;
                     }
-                    KeyCode::End | KeyCode::Char('G')  => {
+                    KeyCode::End | KeyCode::Char('G') => {
                         start_idx = graph_lines.len() - height as usize - 2;
                         should_update = true;
                         // TODO: maybe make this better
@@ -529,7 +529,7 @@ fn print_paged(graph_lines: &[String], text_lines: &[String]) -> Result<(), Erro
                         }
                         should_update = true;
                     }
-                    KeyCode::Home | KeyCode::Char('g')  => {
+                    KeyCode::Home | KeyCode::Char('g') => {
                         start_idx = 0;
                         should_update = true;
                     }


### PR DESCRIPTION
This adds some of the navigation keybinds used in `vim` and `more`, and also adds new blocks for navigating page-up and to the beginning of the output. For consistency, the new blocks also feature both with vim keybinds, and the classic keyboard navigation buttons.
