### PR TITLE
refresh Rust dependencies including necessary refactors, set MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1307,9 +1307,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.14"
 svg = "0.18"
 clap = {version = "4.0", optional = false, features = ["cargo"]}
 lazy_static = "1.4"
-yansi = "0.5"
+yansi = "1.0"
 atty = "0.2"
 platform-dirs = "0.3"
 crossterm = {version = "0.29", optional = false}

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,11 +333,14 @@ fn from_args() -> Result<(), String> {
         match &mode[..] {
             "auto" => {
                 atty::is(atty::Stream::Stdout)
-                    && (!cfg!(windows) || yansi::Paint::enable_windows_ascii())
+                    && (!cfg!(windows) || {
+                        yansi::enable();
+                        yansi::is_enabled()
+                    })
             }
             "always" => {
                 if cfg!(windows) {
-                    yansi::Paint::enable_windows_ascii();
+                    yansi::enable();
                 }
                 true
             }
@@ -350,7 +353,11 @@ fn from_args() -> Result<(), String> {
             }
         }
     } else {
-        atty::is(atty::Stream::Stdout) && (!cfg!(windows) || yansi::Paint::enable_windows_ascii())
+        atty::is(atty::Stream::Stdout)
+            && (!cfg!(windows) || {
+                yansi::enable();
+                yansi::is_enabled()
+            })
     };
 
     let wrapping = if let Some(wrap_values) = matches.get_many::<String>("wrap") {

--- a/src/print/format.rs
+++ b/src/print/format.rs
@@ -118,6 +118,7 @@ pub fn format_commit(
                 add_line(&mut lines, &mut out, wrapping);
             } else {
                 write!(out, "{}", &format[curr..start]).unwrap();
+                let id = commit.id();
                 match idx {
                     HASH => {
                         match mode {
@@ -126,9 +127,9 @@ pub fn format_commit(
                             _ => {}
                         }
                         if let Some(color) = hash_color {
-                            write!(out, "{}", Paint::fixed(color, commit.id()))
+                            write!(out, "{}", id.to_string().fixed(color))
                         } else {
-                            write!(out, "{}", commit.id())
+                            write!(out, "{}", id)
                         }
                     }
                     HASH_ABBREV => {
@@ -138,13 +139,9 @@ pub fn format_commit(
                             _ => {}
                         }
                         if let Some(color) = hash_color {
-                            write!(
-                                out,
-                                "{}",
-                                Paint::fixed(color, &commit.id().to_string()[..7])
-                            )
+                            write!(out, "{}", id.to_string()[..7].fixed(color))
                         } else {
-                            write!(out, "{}", &commit.id().to_string()[..7])
+                            write!(out, "{}", &id.to_string()[..7])
                         }
                     }
                     PARENT_HASHES => {
@@ -405,14 +402,11 @@ pub fn format_oneline(
     hash_color: Option<u8>,
 ) -> Vec<String> {
     let mut out = String::new();
+    let id = commit.id();
     if let Some(color) = hash_color {
-        write!(
-            out,
-            "{}",
-            Paint::fixed(color, &commit.id().to_string()[..7])
-        )
+        write!(out, "{}", id.to_string()[..7].fixed(color))
     } else {
-        write!(out, "{}", &commit.id().to_string()[..7])
+        write!(out, "{}", &id.to_string()[..7])
     }
     .unwrap();
 
@@ -447,10 +441,11 @@ pub fn format(
     let mut out_vec = vec![];
     let mut out = String::new();
 
+    let id = commit.id();
     if let Some(color) = hash_color {
-        write!(out, "commit {}", Paint::fixed(color, &commit.id()))
+        write!(out, "commit {}", id.to_string().fixed(color))
     } else {
-        write!(out, "commit {}", &commit.id())
+        write!(out, "commit {}", &id)
     }
     .map_err(|err| err.to_string())?;
 

--- a/src/print/unicode.rs
+++ b/src/print/unicode.rs
@@ -618,10 +618,11 @@ fn print_graph(
 
         if color {
             for cell in row {
+                let chars = cell.char(characters);
                 if cell.character == SPACE {
-                    write!(g_out, "{}", cell.char(characters))
+                    write!(g_out, "{}", chars)
                 } else {
-                    write!(g_out, "{}", Paint::fixed(cell.color, cell.char(characters)))
+                    write!(g_out, "{}", chars.to_string().fixed(cell.color))
                 }
                 .unwrap();
             }
@@ -682,7 +683,7 @@ pub fn format_branches(
     if let Some(head) = head {
         if !head.is_branch {
             if color {
-                write!(branch_str, " {}", Paint::fixed(HEAD_COLOR, head_str))
+                write!(branch_str, " {}", head_str.fixed(HEAD_COLOR))
             } else {
                 write!(branch_str, " {}", head_str)
             }
@@ -708,7 +709,7 @@ pub fn format_branches(
             if let Some(head) = head {
                 if idx == 0 && head.is_branch {
                     if color {
-                        write!(branch_str, "{} ", Paint::fixed(14, head_str))
+                        write!(branch_str, "{} ", head_str.fixed(14))
                     } else {
                         write!(branch_str, "{} ", head_str)
                     }
@@ -717,7 +718,7 @@ pub fn format_branches(
             }
 
             if color {
-                write!(branch_str, "{}", Paint::fixed(branch_color, &branch.name))
+                write!(branch_str, "{}", &branch.name.fixed(branch_color))
             } else {
                 write!(branch_str, "{}", &branch.name)
             }
@@ -736,10 +737,11 @@ pub fn format_branches(
             let tag = &graph.all_branches[*tag_index];
             let tag_color = curr_color.unwrap_or(&tag.visual.term_color);
 
+            let tag_name = &tag.name[5..];
             if color {
-                write!(branch_str, "{}", Paint::fixed(*tag_color, &tag.name[5..]))
+                write!(branch_str, "{}", tag_name.fixed(*tag_color))
             } else {
-                write!(branch_str, "{}", &tag.name[5..])
+                write!(branch_str, "{}", tag_name)
             }
             .unwrap();
 


### PR DESCRIPTION
This is similar to the cleanup I did over on `git-igitt`. Please don't squash this in case it comes out that downstream deps have other MSRV requirements and we can work backwards though the relevant parts. I don't expect that since this is a pretty conservative requirement, but the commits are carefully separated and sequenced here.

There is *a lot* of code repeated between `git-graph` and `git-igitt`. It will be nice to move on splitting out the library from the CLI so that the CLI and TUI can both just reuse APIs instead of re-inventing the wheel.
